### PR TITLE
Better Android Native system locale acquiring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
+kotlin.mpp.enableCInteropCommonization=true

--- a/i18n4k-core/build.gradle.kts
+++ b/i18n4k-core/build.gradle.kts
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     id("i18n4k.kmp-build")
@@ -11,6 +13,19 @@ plugins {
 kotlin {
     // the sources of all the targets
     @Suppress("UnusedPrivateMember")
+
+    targets.withType<KotlinNativeTarget> {
+        if (name.startsWith("androidNative")) {
+            compilations.getByName("main") {
+                cinterops {
+                    create("sysprop") {
+                        definitionFile.set(project.layout.projectDirectory.file("src/androidNativeMain/cinterop/sysprop.def"))
+                    }
+                }
+            }
+        }
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/i18n4k-core/src/androidNativeMain/cinterop/sysprop.def
+++ b/i18n4k-core/src/androidNativeMain/cinterop/sysprop.def
@@ -1,0 +1,2 @@
+headers = sys/system_properties.h
+package = sysprop

--- a/i18n4k-core/src/androidNativeMain/kotlin/de/comahe/i18n4k/CInterop.kt
+++ b/i18n4k-core/src/androidNativeMain/kotlin/de/comahe/i18n4k/CInterop.kt
@@ -1,0 +1,80 @@
+package de.comahe.i18n4k
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import platform.posix.__system_property_get
+import platform.posix.getenv
+import sysprop.PROP_VALUE_MAX
+
+@OptIn(ExperimentalForeignApi::class)
+internal object CInterop {
+
+    private const val PROP_LOCALE = "persist.sys.locale"
+    private const val PROP_LANGUAGE = "persist.sys.language"
+    private const val PROP_COUNTRY = "persist.sys.country"
+
+    /**
+     * Acquires the system [Locale] on Android natively without JNI.
+     * Does not work 100% as some vendors mess with system properties.
+     */
+    fun systemLocale(): Locale? {
+        return systemLocaleFromProperty() ?: systemLocaleFromEnvironment()
+    }
+
+    /**
+     * Checks the environment if a LANG attribute exists and returns it as [Locale].
+     * Pretty uncommon on Android.
+     */
+    private fun systemLocaleFromEnvironment(): Locale? {
+        return getenv("LANG")?.toKString()?.substringBefore('.')?.trim()?.parseLocale()
+    }
+
+    /**
+     * Checks the system properties to read and parse a [Locale].
+     * Pretty common on Android.
+     */
+    private fun systemLocaleFromProperty(): Locale? {
+        systemProperty(PROP_LOCALE).parseLocale()?.let {
+            return it
+        }
+
+        val lang = systemProperty(PROP_LANGUAGE)
+        val country = systemProperty(PROP_COUNTRY)
+
+        return if (!lang.isNullOrBlank()) {
+            buildString {
+                append(lang)
+                if (!country.isNullOrBlank()) {
+                    append("-$country")
+                }
+            }.parseLocale()
+        } else {
+            null
+        }
+    }
+
+    private fun String?.parseLocale(): Locale? {
+        return try {
+            this?.ifBlank { null }?.let(::forLocaleTag)?.takeUnless {
+                it.getLanguage().isBlank() && it.getCountry().isBlank()
+            }
+        } catch (ignored: Throwable) {
+            // probably an invalid tag, like "C"
+            null
+        }
+    }
+
+    private fun systemProperty(key: String): String? = memScoped {
+        val buffer = allocArray<ByteVar>(PROP_VALUE_MAX)
+        val len = __system_property_get(key, buffer)
+
+        if (len > 0) {
+            buffer.toKString().ifBlank { null }?.trim()
+        } else {
+            null
+        }
+    }
+}

--- a/i18n4k-core/src/androidNativeMain/kotlin/de/comahe/i18n4k/Locale.androidNative.kt
+++ b/i18n4k-core/src/androidNativeMain/kotlin/de/comahe/i18n4k/Locale.androidNative.kt
@@ -8,18 +8,5 @@ import platform.posix.getenv
 @OptIn(ExperimentalForeignApi::class)
 actual val systemLocale: Locale
     get() {
-        var locale: Locale? = null
-        try {
-            val tag = getenv("LANG")?.toKString()?.substringBefore('.')?.trim()?.ifBlank { null }
-
-            locale = tag?.let(::forLocaleTag)?.takeUnless {
-                it.getLanguage().isBlank() && it.getCountry().isBlank()
-            }
-        } catch (ignore: Throwable) {
-            //probably an invalid tag, like "C"
-        }
-        if (locale == null) {
-            locale = Locale("en")
-        }
-        return locale
+        return CInterop.systemLocale() ?: Locale("en")
     }


### PR DESCRIPTION
Uses cinterop to get the system locale.

This is much more consistent than the previous implementation, but still not 100%.
For a 100%, we would need to call the JVM, however according to ChatGPT we target 95% with this.

I tested it on all my devices (physical ones and emulators) and it worked on all of them.